### PR TITLE
fix footer

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -19,7 +19,7 @@ function Footer() {
           <li><Link href='/cgu'><a>Mentions légales</a></Link></li>
           <li><Link href='/faq'><a>FAQ</a></Link></li>
           <li><a href='mailto:adresse@data.gouv.fr'>Contact API adresse</a></li>
-          <li><a href='mailto:geo@data.gouv.fr'>Contact API découpage administratif</a></li>
+          <li><Link href='https://support.data.gouv.fr/autre/geo'><a>Contact API découpage administratif</a></Link></li>
         </ul>
       </div>
       <style jsx>{`


### PR DESCRIPTION
@ThomasG77 L’adresse mail geo@data.gouv.fr en footer n'est plus fonctionnelle (cf https://twitter.com/maximepvrt/status/1658098663908864000)

Le formulaire [https://etalab.gouv.fr/contact/](https://etalab.gouv.fr/contact/) est également plus fonctionnel 